### PR TITLE
Use prepared statements in user management

### DIFF
--- a/app/class.engine.php
+++ b/app/class.engine.php
@@ -61,6 +61,11 @@ class engine
         return $this->connection->query($sql);
     }
 
+    public function prepare($sql)
+    {
+        return $this->connection->prepare($sql);
+    }
+
     public function num_rows($sql)
     {
         return $this->query($sql)->rowCount();

--- a/app/interfaces/interface.engine.php
+++ b/app/interfaces/interface.engine.php
@@ -15,7 +15,9 @@ interface iEngine
 	
 	public function secure($var);
 	
-	public function query($sql);
+        public function query($sql);
+
+        public function prepare($sql);
 	
 	public function num_rows($sql);
 	


### PR DESCRIPTION
## Summary
- expose `prepare()` in engine
- switch user queries to PDO prepared statements
- update engine interface

## Testing
- `php -l app/class.engine.php`
- `php -l app/interfaces/interface.engine.php`
- `php -l app/class.users.php`


------
https://chatgpt.com/codex/tasks/task_e_688a20805374832389929eae91b18454