### PR TITLE
Refactor templates to use PDO

### DIFF
--- a/app/tpl/class.forms.php
+++ b/app/tpl/class.forms.php
@@ -59,12 +59,14 @@ class forms implements iForms
 			{
 				$_GET['id'] = 1;
 			}
-				$result = mysql_query("SELECT title, id FROM cms_news WHERE id != '" . $engine->secure($_GET['id']) . "' ORDER BY id DESC");
-				
-				while($news1 = mysql_fetch_array($result))
-				{
-					$template->setParams('newsList', '&laquo; <a href="index.php?url=news&id='.$news1["id"].'">' . $news1['title'] . '</a><br/>');
-				}
+                                $stmt = $engine->prepare("SELECT title, id FROM cms_news WHERE id != :id ORDER BY id DESC");
+                                $stmt->bindValue(':id', $_GET['id'], \PDO::PARAM_INT);
+                                $stmt->execute();
+                                while($news1 = $stmt->fetch())
+                                {
+                                        $template->setParams('newsList', '&laquo; <a href="index.php?url=news&id='.$news1["id"].'">' . $news1['title'] . '</a><br/>');
+                                }
+                                $engine->free_result($stmt);
 				
 				$news = $engine->fetch_assoc("SELECT title, longstory, author, published FROM cms_news WHERE id = '" . $engine->secure($_GET['id']) . "' LIMIT 1");
 				$template->setParams('newsTitle', $news['title']);
@@ -80,22 +82,22 @@ class forms implements iForms
 	final public function getPageHome()
 	{
 		global $template, $engine;
-		$a = 1;
-		$data = mysql_query("SELECT title, id, published, shortstory, image FROM cms_news ORDER BY id DESC LIMIT 5");
-                
-        while($news = mysql_fetch_array($data, MYSQL_ASSOC))
-       	{
+                $a = 1;
+                $stmt = $engine->query("SELECT title, id, published, shortstory, image FROM cms_news ORDER BY id DESC LIMIT 5");
+
+        while($news = $stmt->fetch())
+        {
             $template->setParams('newsTitle-' . $a, $news['title']);
             $template->setParams('newsID-' . $a, $news['id']);
             $template->setParams('newsDate-' . $a, date("d-m-y", $news['published']));
             $template->setParams('newsCaption-' . $a, $news['shortstory']);
             $template->setParams('newsIMG-' . $a, $news['image']);
-        	$a++;
+                $a++;
         }
-        
+
         unset($news);
-        unset($data);
-	}
+        $engine->free_result($stmt);
+        }
 	
 }
 

--- a/app/tpl/skins/Mango/hk/banlist.php
+++ b/app/tpl/skins/Mango/hk/banlist.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 7)
+                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>
+                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />
@@ -56,11 +56,13 @@
           <table width="100%">
 <tr><td><b>Username</b></td><td><b>Reason</b></td><td><b>Banned by</b></td><td><b>Value</b></td></tr>
 <?php
-	while($two = mysql_fetch_array(mysql_query("SELECT * FROM bans"), MYSQL_ASSOC))
-	{
-		echo "<tr><td>" . $two['value'] ."</td><td>" . $two['reason'] . "</td><td>" . $two['added_by'] . "</td><td><a href='?url=banlist&unban=" . $two['id'] . "'><b>Unban</b></a></td></tr>";
-	}
-	
+        $stmt = $engine->query("SELECT * FROM bans");
+        while($two = $stmt->fetch())
+        {
+                echo "<tr><td>" . $two['value'] ."</td><td>" . $two['reason'] . "</td><td>" . $two['added_by'] . "</td><td><a href='?url=banlist&unban=" . $two['id'] . "'><b>Unban</b></a></td></tr>";
+        }
+        $engine->free_result($stmt);
+
 ?>
 
 </table>

--- a/app/tpl/skins/Mango/hk/dash.php
+++ b/app/tpl/skins/Mango/hk/dash.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 7)
+                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>
+                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />

--- a/app/tpl/skins/Mango/hk/edit.php
+++ b/app/tpl/skins/Mango/hk/edit.php
@@ -1,1 +1,125 @@
-  <div id="main">    <div id="links"></div>    <div id="header">      <div id="logo">        <div id="logo_text">          <!-- class="logo_colour", allows you to change the color of the logo text -->          <h1>ASE</h1>        </div>      </div>    </div>    <div id="site_content">      <div id="sidebar_container">        <!-- insert your sidebar items here -->        <div class="sidebar">          <div class="sidebar_top"></div>          <div class="sidebar_item">           <br />		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />            <p>			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) > 6)			{ ?>			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />			&raquo; <a href='vip'>Give a user Regular VIP</a> <br />			&raquo; <a href='svip'>Give a user Super VIP</a> <br />			&raquo; <a href='edit'>Edit a users account</a> <br />			<br />			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='news'>Post news article</a><br />			<br />			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='banlist'>Ban List</a> <br />			&raquo; <a href='ip'>IP lookup</a> <br />			<br />						<?php } ?>			<br />			Statistics<br />			<img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />					Server Status: 			{status} <br />			{online} user(s) online <br />				</p>          </div>          <div class="sidebar_base"></div>        </div>      </div>      <div id="content_container">        <div id="content">          <!-- insert the page content here -->          <br />                   <?php                  if(isset($_POST['update']))		{			mysql_query("UPDATE users SET username = '" . filter($_POST['username']) . "', mail = '" . filter($_POST['email']) . 		"', motto = '" . filter($_POST['motto']) . "', rank = '" . filter($_POST['rank']) . "', credits = '" . filter($_POST['credits']) . "', activity_points = '" . filter($_POST['pixels']) . "' WHERE username = '" . filter($_POST['username_current']) . "'") or die(mysql_error());			 	echo $_POST['username_current'] . "'s account updated."; 		}		if(isset($_POST['lookup'])){			if(mysql_num_rows(mysql_query("SELECT * FROM users WHERE username = '". filter($_POST['l_username']) ."'")) == 0) { echo "User does not exist."; }	else { 				$two = mysql_fetch_assoc(mysql_query("SELECT * FROM users WHERE username = '" . filter($_POST['l_username']) . "'"));	?>		Editing account: <?php echo $username; ?></a>	<form method='post'>	<input type="hidden" name="username_current" value="<?php echo $_POST['l_username']; ?>" />			<table style="width: 100%;">							<tr>				<td>Username</td></td>				<td><input type="text" name="username" value="<?php echo $_POST['l_username']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Email</td>				<td><input type="text" name="email" value="<?php echo $two['mail']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Motto</td>				<td><input type="text" name="motto" value="<?php echo $two['motto']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Rank</td>				<td><input type="text" name="rank" value="<?php echo $two['rank']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Credits</td>				<td><input type="text" name="credits" value="<?php echo $two['credits']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Pixels</td>				<td><input type="text" name="pixels" value="<?php echo $two['activity_points']; ?>" style="width: 95%" /></td>			</tr>		</table>		<input type="submit" value="  Update account  " name="update"/>	</form>	<br />	<?php	}	}	?>	<form method='post'>	Username <br /> <input type="text" name="l_username" /> <br /> <br />	<input type="submit" value="  Lookup user  " name="lookup"/>	</form></div>        </div>      </div>    </div>  </div>   <center>Powered by ZapASE by Jontycat - Design by Predict</center>   <center>Implemented into RevCMS by Kryptos</center><br />
+  <div id="main">
+    <div id="links"></div>
+    <div id="header">
+      <div id="logo">
+        <div id="logo_text">
+          <!-- class="logo_colour", allows you to change the color of the logo text -->
+          <h1>ASE</h1>
+        </div>
+      </div>
+    </div>
+    <div id="site_content">
+      <div id="sidebar_container">
+        <!-- insert your sidebar items here -->
+        <div class="sidebar">
+          <div class="sidebar_top"></div>
+          <div class="sidebar_item">
+           <br />
+		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
+            <p>
+			<?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") > 6)
+			{ ?>
+			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
+			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
+			&raquo; <a href='vip'>Give a user Regular VIP</a> <br />
+			&raquo; <a href='svip'>Give a user Super VIP</a> <br />
+			&raquo; <a href='edit'>Edit a users account</a> <br />
+			<br />
+			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
+			&raquo; <a href='news'>Post news article</a><br />
+			<br />
+			<?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
+			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
+			&raquo; <a href='banlist'>Ban List</a> <br />
+			&raquo; <a href='ip'>IP lookup</a> <br />
+			<br />
+			
+			<?php } ?>
+			<br />
+			Statistics<br />
+			<img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
+					Server Status: 
+			{status} <br />
+			{online} user(s) online <br />
+	
+			</p>
+          </div>
+          <div class="sidebar_base"></div>
+        </div>
+      </div>
+      <div id="content_container">
+
+        <div id="content">
+          <!-- insert the page content here -->
+          <br />          
+         <?php
+          
+        if(isset($_POST['update']))
+		{
+                        $stmt = $engine->prepare("UPDATE users SET username = ?, mail = ?, motto = ?, rank = ?, credits = ?, activity_points = ? WHERE username = ?");
+                        $stmt->execute([filter($_POST["username"]), filter($_POST["email"]), filter($_POST["motto"]), filter($_POST["rank"]), filter($_POST["credits"]), filter($_POST["pixels"]), filter($_POST["username_current"])]);
+		}
+		
+
+if(isset($_POST['lookup']))
+{	
+	
+        $stmt = $engine->prepare("SELECT * FROM users WHERE username = ?");
+        $stmt->execute([filter($_POST["l_username"])]);
+        if($stmt->rowCount() == 0) { echo "User does not exist."; }
+        else {
+                                $two = $stmt->fetch();
+?>
+	Editing account: <?php echo $username; ?></a>
+	<form method='post'>
+	<input type="hidden" name="username_current" value="<?php echo $_POST['l_username']; ?>" />
+	
+		<table style="width: 100%;">
+				
+			<tr>
+				<td>Username</td></td>
+				<td><input type="text" name="username" value="<?php echo $_POST['l_username']; ?>" style="width: 95%" /></td>
+			</tr>
+			<tr>
+				<td>Email</td>
+				<td><input type="text" name="email" value="<?php echo $two['mail']; ?>" style="width: 95%" /></td>
+			</tr>
+			<tr>
+				<td>Motto</td>
+				<td><input type="text" name="motto" value="<?php echo $two['motto']; ?>" style="width: 95%" /></td>
+			</tr>
+			<tr>
+				<td>Rank</td>
+				<td><input type="text" name="rank" value="<?php echo $two['rank']; ?>" style="width: 95%" /></td>
+			</tr>
+			<tr>
+				<td>Credits</td>
+				<td><input type="text" name="credits" value="<?php echo $two['credits']; ?>" style="width: 95%" /></td>
+			</tr>
+			<tr>
+				<td>Pixels</td>
+				<td><input type="text" name="pixels" value="<?php echo $two['activity_points']; ?>" style="width: 95%" /></td>
+			</tr>
+		</table>
+		<input type="submit" value="  Update account  " name="update"/>
+	</form>
+	<br />
+	<?php
+	}
+	}
+	?>
+
+	<form method='post'>
+	Username <br /> <input type="text" name="l_username" /> <br /> <br />
+	<input type="submit" value="  Lookup user  " name="lookup"/>
+	</form>
+
+</div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+   <center>Powered by ZapASE by Jontycat - Design by Predict</center>
+   <center>Implemented into RevCMS by Kryptos</center><br />
+    <div id="links"></div>    <div id="header">      <div id="logo">        <div id="logo_text">          <!-- class="logo_colour", allows you to change the color of the logo text -->          <h1>ASE</h1>        </div>      </div>    </div>    <div id="site_content">      <div id="sidebar_container">        <!-- insert your sidebar items here -->        <div class="sidebar">          <div class="sidebar_top"></div>          <div class="sidebar_item">           <br />		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />            <p>			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) > 6)			{ ?>			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />			&raquo; <a href='vip'>Give a user Regular VIP</a> <br />			&raquo; <a href='svip'>Give a user Super VIP</a> <br />			&raquo; <a href='edit'>Edit a users account</a> <br />			<br />			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='news'>Post news article</a><br />			<br />			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='banlist'>Ban List</a> <br />			&raquo; <a href='ip'>IP lookup</a> <br />			<br />						<?php } ?>			<br />			Statistics<br />			<img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />					Server Status: 			{status} <br />			{online} user(s) online <br />				</p>          </div>          <div class="sidebar_base"></div>        </div>      </div>      <div id="content_container">        <div id="content">          <!-- insert the page content here -->          <br />                   <?php                  if(isset($_POST['update']))		{			mysql_query("UPDATE users SET username = '" . filter($_POST['username']) . "', mail = '" . filter($_POST['email']) . 		"', motto = '" . filter($_POST['motto']) . "', rank = '" . filter($_POST['rank']) . "', credits = '" . filter($_POST['credits']) . "', activity_points = '" . filter($_POST['pixels']) . "' WHERE username = '" . filter($_POST['username_current']) . "'") or die(mysql_error());			 	echo $_POST['username_current'] . "'s account updated."; 		}		if(isset($_POST['lookup'])){			if(mysql_num_rows(mysql_query("SELECT * FROM users WHERE username = '". filter($_POST['l_username']) ."'")) == 0) { echo "User does not exist."; }	else { 				$two = mysql_fetch_assoc(mysql_query("SELECT * FROM users WHERE username = '" . filter($_POST['l_username']) . "'"));	?>		Editing account: <?php echo $username; ?></a>	<form method='post'>	<input type="hidden" name="username_current" value="<?php echo $_POST['l_username']; ?>" />			<table style="width: 100%;">							<tr>				<td>Username</td></td>				<td><input type="text" name="username" value="<?php echo $_POST['l_username']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Email</td>				<td><input type="text" name="email" value="<?php echo $two['mail']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Motto</td>				<td><input type="text" name="motto" value="<?php echo $two['motto']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Rank</td>				<td><input type="text" name="rank" value="<?php echo $two['rank']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Credits</td>				<td><input type="text" name="credits" value="<?php echo $two['credits']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Pixels</td>				<td><input type="text" name="pixels" value="<?php echo $two['activity_points']; ?>" style="width: 95%" /></td>			</tr>		</table>		<input type="submit" value="  Update account  " name="update"/>	</form>	<br />	<?php	}	}	?>	<form method='post'>	Username <br /> <input type="text" name="l_username" /> <br /> <br />	<input type="submit" value="  Lookup user  " name="lookup"/>	</form></div>        </div>      </div>    </div>  </div>   <center>Powered by ZapASE by Jontycat - Design by Predict</center>   <center>Implemented into RevCMS by Kryptos</center><br />

--- a/app/tpl/skins/Mango/hk/ip.php
+++ b/app/tpl/skins/Mango/hk/ip.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 7)
+                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>
+                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />
@@ -56,15 +56,21 @@
           <table width="100%">
 <tr><td><b>Username</b></td><td><b>E-Mail</b></td><td><b>IP</b></td></tr>
 <?php
-	if(isset($_POST['get_ip']))
-	{
-		$derp = mysql_fetch_array(mysql_query("SELECT ip_last FROM users WHERE username = '" . filter($_POST['username']) . "'"), MYSQL_ASSOC);
-		$lerp = mysql_query("SELECT * FROM users WHERE ip_last = '" . $derp['ip_last'] . "'");
-		
-		echo "There are " . mysql_num_rows($lerp) . " account(s) on this IP. <br /><br />";
-		while($ferp = mysql_fetch_array($lerp, MYSQL_ASSOC)) {
-		echo "<tr><td>" . $ferp['username'] . "</td><td>" . $ferp['mail'] . "</td><td>" . $ferp['ip_last'] . "</td></tr>"; }
-	} ?>
+        if(isset($_POST['get_ip']))
+        {
+                $stmt = $engine->prepare("SELECT ip_last FROM users WHERE username = ?");
+                $stmt->execute([filter($_POST['username'])]);
+                $derp = $stmt->fetch();
+                $engine->free_result($stmt);
+                $stmt = $engine->prepare("SELECT * FROM users WHERE ip_last = ?");
+                $stmt->execute([$derp['ip_last']]);
+                $accounts = $stmt->fetchAll();
+
+                echo "There are " . count($accounts) . " account(s) on this IP. <br /><br />";
+                foreach($accounts as $ferp) {
+                echo "<tr><td>" . $ferp['username'] . "</td><td>" . $ferp['mail'] . "</td><td>" . $ferp['ip_last'] . "</td></tr>"; }
+                $engine->free_result($stmt);
+        } ?>
 	
 	<form method='post'>
 	Username <br /> <input type="text" name="username" /> <br /> <br />

--- a/app/tpl/skins/Mango/hk/news.php
+++ b/app/tpl/skins/Mango/hk/news.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 7)
+                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>
+                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />
@@ -54,7 +54,7 @@
           <br />         
         <?php
 
-if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 7)
+if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
 {
 	if(isset($_GET["done"]))
 	{
@@ -75,7 +75,7 @@ if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['u
 		{
 			$_SESSION["title"] = filter($_POST["title"]);
 			$_SESSION["shortstory"] = filter($_POST["shortstory"]);
-			$_SESSION["longstory"] = mysql_real_escape_string($_POST["longstory"]);
+                        $_SESSION["longstory"] = filter($_POST["longstory"]);
 			
 			header("Location: ".$_CONFIG['hotel']['url']."/ase/news2");
 			exit;

--- a/app/tpl/skins/Mango/hk/news2.php
+++ b/app/tpl/skins/Mango/hk/news2.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 7)
+                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>
+                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />
@@ -62,8 +62,12 @@ if(!isset($_SESSION["longstory"]))
 
 if(isset($_POST["proceed"]))
 {
-	$author = mysql_result(mysql_query("SELECT username FROM users WHERE id = '".$_SESSION['user']['id']."' LIMIT 1"), 0);
-	mysql_query("INSERT INTO cms_news (title,shortstory,longstory,published,image,author, campaign, campaignimg) VALUES ('" . filter($_SESSION["title"]) . "', '" . filter($_SESSION["shortstory"]) . "', '" . filter($_SESSION["longstory"]) . "', '" . time() . "', '" . filter($_POST["topstory"]) . "', '" . filter($author) . "', 0, 'default')") or die(mysql_error());
+        $stmt = $engine->prepare("SELECT username FROM users WHERE id = ? LIMIT 1");
+        $stmt->execute([$_SESSION['user']['id']]);
+        $author = $stmt->fetchColumn();
+        $engine->free_result($stmt);
+        $stmt = $engine->prepare("INSERT INTO cms_news (title,shortstory,longstory,published,image,author, campaign, campaignimg) VALUES (?, ?, ?, ?, ?, ?, 0, 'default')");
+        $stmt->execute([filter($_SESSION["title"]), filter($_SESSION["shortstory"]), filter($_SESSION["longstory"]), time(), filter($_POST["topstory"]), filter($author)]);
 	unset($_SESSION["title"], $_SESSION["shortstory"], $_SESSION["longstory"]);
 	header("Location: ".$_CONFIG['hotel']['url']."/ase/");
 	exit;

--- a/app/tpl/skins/Mango/hk/svip.php
+++ b/app/tpl/skins/Mango/hk/svip.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 7)
+                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>
+                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />
@@ -55,12 +55,14 @@
           
      <?php
      
-	if(isset($_POST['give']))
-	{	
-		if(mysql_num_rows(mysql_query("SELECT * FROM users WHERE username = '" . filter($_POST['username']) . "'"))){ echo "User does not exist."; }
-		else {
-		$engine->query("UPDATE users SET rank = 3, credits = credits + '2000000', activity_points = activity_points + '2000000' WHERE username = '" . filter($_POST['username']) . "'"); }
-	}
+        if(isset($_POST['give']))
+        {
+                $stmt = $engine->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
+                $stmt->execute([filter($_POST['username'])]);
+                if($stmt->fetchColumn() == 0){ echo "User does not exist."; }
+                else {
+                $engine->query("UPDATE users SET rank = 3, credits = credits + '2000000', activity_points = activity_points + '2000000' WHERE username = '" . filter($_POST['username']) . "'"); }
+        }
 	
 ?>
 				<form method="post">

--- a/app/tpl/skins/Mango/hk/vip.php
+++ b/app/tpl/skins/Mango/hk/vip.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 7)
+                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>
+                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />
@@ -53,13 +53,16 @@
           <!-- insert the page content here -->
           <br /> 
           <?php
-	if(isset($_POST['give']))
-	{	
-		if(mysql_num_rows(mysql_query("SELECT * FROM users WHERE username = '" . filter($_POST['username']) . "'"))){ echo "User does not exist."; }
-		else {
-		mysql_query("UPDATE users SET rank = 2, credits = credits + '200000', activity_points = activity_points + '200000' WHERE username = '" . $_POST['username'] . "'");
-		}
-	}
+        if(isset($_POST['give']))
+        {
+                $stmt = $engine->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
+                $stmt->execute([filter($_POST['username'])]);
+                if($stmt->fetchColumn() == 0){ echo "User does not exist."; }
+                else {
+                $stmt = $engine->prepare("UPDATE users SET rank = 2, credits = credits + '200000', activity_points = activity_points + '200000' WHERE username = ?");
+                $stmt->execute([$_POST['username']]);
+                }
+        }
 	
 ?>
 				<form method="post">

--- a/app/tpl/skins/Mango/me.php
+++ b/app/tpl/skins/Mango/me.php
@@ -38,20 +38,23 @@ Welcome back to {hotelName}, {username}!
 <div id="main_left"> 
 
 <?php
-	$GetRanks = mysql_query("SELECT id,name FROM ranks WHERE id > 3 ORDER BY id DESC");
-	while($Ranks = mysql_fetch_assoc($GetRanks))
-	{
-		echo "<div class=\"content-box\" style=\"background-color:#fff\"><div class=\"content-box-deep-blue\"><h2 class=\"title\" style=\"padding:0;line-height:30px;\">{$Ranks['name']}s</h2></div><div class=\"content-box-content\"><p>";
-		$GetUsers = mysql_query("SELECT username,motto,rank,last_online,online,look FROM users WHERE rank = {$Ranks['id']}");
-		while($Users = mysql_fetch_assoc($GetUsers))
-		{
-			if($Users['online'] == 1){ $OnlineStatus = "<font color=\"darkgreen\"><blink><b>Online</b></blink></font>"; } else { $OnlineStatus = "<font color=\"darkred\"><marquee><b>Offline</b></marquee></font>"; }
-			echo "<img style=\"position:absolute;\" src=\"http://www.habbo.com/habbo-imaging/avatarimage?figure={$Users['look']}&action=wav&direction=2&head_direction=3&gesture=srp&size=l\">"
-				."<p style=\"margin-left:80px;margin-top:20px;\">Username: <strong>{$Users['username']}</strong><br>Motto: <strong>{$Users['motto']}</strong><br><small>Last Online: ". date("D, d F Y H:i (P)", $Users['last_online']) ."</small></p>"
-				."<p style=\"float:right;margin-top:-30px;\">{$OnlineStatus}</p><br><br><br>";
-		}
-		echo "</p></div></div><br>";
-	}
+        $stmtRanks = $engine->query("SELECT id,name FROM ranks WHERE id > 3 ORDER BY id DESC");
+        while($Ranks = $stmtRanks->fetch())
+        {
+                echo "<div class=\"content-box\" style=\"background-color:#fff\"><div class=\"content-box-deep-blue\"><h2 class=\"title\" style=\"padding:0;line-height:30px;\">{$Ranks['name']}s</h2></div><div class=\"content-box-content\"><p>";
+                $stmtUsers = $engine->prepare("SELECT username,motto,rank,last_online,online,look FROM users WHERE rank = ?");
+                $stmtUsers->execute([$Ranks['id']]);
+                while($Users = $stmtUsers->fetch())
+                {
+                        if($Users['online'] == 1){ $OnlineStatus = "<font color=\"darkgreen\"><blink><b>Online</b></blink></font>"; } else { $OnlineStatus = "<font color=\"darkred\"><marquee><b>Offline</b></marquee></font>"; }
+                        echo "<img style=\"position:absolute;\" src=\"http://www.habbo.com/habbo-imaging/avatarimage?figure={$Users['look']}&action=wav&direction=2&head_direction=3&gesture=srp&size=l\">"
+                                ."<p style=\"margin-left:80px;margin-top:20px;\">Username: <strong>{$Users['username']}</strong><br>Motto: <strong>{$Users['motto']}</strong><br><small>Last Online: ". date("D, d F Y H:i (P)", $Users['last_online']) ."</small></p>"
+                                ."<p style=\"float:right;margin-top:-30px;\">{$OnlineStatus}</p><br><br><br>";
+                }
+                $engine->free_result($stmtUsers);
+                echo "</p></div></div><br>";
+        }
+        $engine->free_result($stmtRanks);
 ?>
 
 

--- a/app/tpl/skins/Mango/staff.php
+++ b/app/tpl/skins/Mango/staff.php
@@ -38,20 +38,23 @@ Welcome back to {hotelName}, {username}!
 <div id="main_left"> 
 
 <?php
-	$GetRanks = mysql_query("SELECT id,name FROM ranks WHERE id > 3 ORDER BY id DESC");
-	while($Ranks = mysql_fetch_assoc($GetRanks))
-	{
-		echo "<div class=\"content-box\" style=\"background-color:#fff\"><div class=\"content-box-deep-blue\"><h2 class=\"title\" style=\"padding:0;line-height:30px;\">{$Ranks['name']}s</h2></div><div class=\"content-box-content\"><p>";
-		$GetUsers = mysql_query("SELECT username,motto,rank,last_online,online,look FROM users WHERE rank = {$Ranks['id']}");
-		while($Users = mysql_fetch_assoc($GetUsers))
-		{
-			if($Users['online'] == 1){ $OnlineStatus = "<font color=\"darkgreen\"><blink><b>Online</b></blink></font>"; } else { $OnlineStatus = "<font color=\"darkred\"><marquee><b>Offline</b></marquee></font>"; }
-			echo "<img style=\"position:absolute;\" src=\"http://www.habbo.com/habbo-imaging/avatarimage?figure={$Users['look']}&action=wav&direction=2&head_direction=3&gesture=srp&size=l\">"
-				."<p style=\"margin-left:80px;margin-top:20px;\">Username: <strong>{$Users['username']}</strong><br>Motto: <strong>{$Users['motto']}</strong><br><small>Last Online: ". date("D, d F Y H:i (P)", $Users['last_online']) ."</small></p>"
-				."<p style=\"float:right;margin-top:-30px;\">{$OnlineStatus}</p><br><br><br>";
-		}
-		echo "</p></div></div><br>";
-	}
+        $stmtRanks = $engine->query("SELECT id,name FROM ranks WHERE id > 3 ORDER BY id DESC");
+        while($Ranks = $stmtRanks->fetch())
+        {
+                echo "<div class=\"content-box\" style=\"background-color:#fff\"><div class=\"content-box-deep-blue\"><h2 class=\"title\" style=\"padding:0;line-height:30px;\">{$Ranks['name']}s</h2></div><div class=\"content-box-content\"><p>";
+                $stmtUsers = $engine->prepare("SELECT username,motto,rank,last_online,online,look FROM users WHERE rank = ?");
+                $stmtUsers->execute([$Ranks['id']]);
+                while($Users = $stmtUsers->fetch())
+                {
+                        if($Users['online'] == 1){ $OnlineStatus = "<font color=\"darkgreen\"><blink><b>Online</b></blink></font>"; } else { $OnlineStatus = "<font color=\"darkred\"><marquee><b>Offline</b></marquee></font>"; }
+                        echo "<img style=\"position:absolute;\" src=\"http://www.habbo.com/habbo-imaging/avatarimage?figure={$Users['look']}&action=wav&direction=2&head_direction=3&gesture=srp&size=l\">"
+                                ."<p style=\"margin-left:80px;margin-top:20px;\">Username: <strong>{$Users['username']}</strong><br>Motto: <strong>{$Users['motto']}</strong><br><small>Last Online: ". date("D, d F Y H:i (P)", $Users['last_online']) ."</small></p>"
+                                ."<p style=\"float:right;margin-top:-30px;\">{$OnlineStatus}</p><br><br><br>";
+                }
+                $engine->free_result($stmtUsers);
+                echo "</p></div></div><br>";
+        }
+        $engine->free_result($stmtRanks);
 ?>
 
 


### PR DESCRIPTION
## Summary
- remove deprecated mysql_* calls from template PHP files
- switch to engine PDO methods using prepared statements

## Testing
- `php -l app/tpl/class.forms.php`
- `php -l app/tpl/skins/Mango/hk/banlist.php`
- `php -l app/tpl/skins/Mango/hk/dash.php`
- `php -l app/tpl/skins/Mango/hk/edit.php`
- `php -l app/tpl/skins/Mango/hk/ip.php`
- `php -l app/tpl/skins/Mango/hk/news.php`
- `php -l app/tpl/skins/Mango/hk/news2.php`
- `php -l app/tpl/skins/Mango/hk/svip.php`
- `php -l app/tpl/skins/Mango/hk/vip.php`
- `php -l app/tpl/skins/Mango/me.php`
- `php -l app/tpl/skins/Mango/staff.php`


------
https://chatgpt.com/codex/tasks/task_e_688a242f98288323a07f33e2412053dc