### PR TITLE
Add CSRF token protection

### DIFF
--- a/app/class.users.php
+++ b/app/class.users.php
@@ -34,15 +34,20 @@ class users implements iUsers
 		return preg_match("/^[a-z0-9_\.-]+@([a-z0-9]+([\-]+[a-z0-9]+)*\.)+[a-z]{2,7}$/i", $email); 	
 	} 	 	
 	
-	final public function validSecKey($seckey)
-	{
-		if(is_numeric($seckey) && strlen($seckey) == 4)
-		{
-			return true;
-		}
-		
-		return false;
-	}
+        final public function validSecKey($seckey)
+        {
+                if(is_numeric($seckey) && strlen($seckey) == 4)
+                {
+                        return true;
+                }
+
+                return false;
+        }
+
+        private function validCsrf()
+        {
+                return isset($_POST['csrf_token'], $_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $_POST['csrf_token']);
+        }
 	
         final public function nameTaken($username)
         {
@@ -108,9 +113,14 @@ class users implements iUsers
 	{
 		global $core, $template, $_CONFIG;
 		
-		if(isset($_POST['register']))
-		{
-			unset($template->form->error);
+                if(isset($_POST['register']))
+                {
+                        if(!$this->validCsrf())
+                        {
+                                $template->form->error = 'Invalid CSRF token';
+                                return;
+                        }
+                        unset($template->form->error);
 			
 			$template->form->setData();
 				
@@ -207,9 +217,14 @@ class users implements iUsers
 	{
 		global $template, $_CONFIG, $core;
 		
-		if(isset($_POST['login']))
-		{
-			$template->form->setData();
+                if(isset($_POST['login']))
+                {
+                        if(!$this->validCsrf())
+                        {
+                                $template->form->error = 'Invalid CSRF token';
+                                return;
+                        }
+                        $template->form->setData();
 			unset($template->form->error);
 			
 			if($this->nameTaken($template->form->log_username))
@@ -317,8 +332,13 @@ class users implements iUsers
 	{
 		global $template, $_CONFIG, $core, $engine;
 		
-		if(isset($_POST['account']))
-		{
+                if(isset($_POST['account']))
+                {
+                        if(!$this->validCsrf())
+                        {
+                                $template->form->error = 'Invalid CSRF token';
+                                return;
+                        }
 		
 			if(isset($_POST['acc_motto']) && strlen($_POST['acc_motto']) < 30 && $_POST['acc_motto'] != $this->getInfo($_SESSION['user']['id'], 'motto'))
 			{
@@ -387,8 +407,13 @@ class users implements iUsers
 	{
 		global $template, $_CONFIG, $core;
 		
-		if(isset($_POST['forgot']))
-		{
+                if(isset($_POST['forgot']))
+                {
+                        if(!$this->validCsrf())
+                        {
+                                $template->form->error = 'Invalid CSRF token';
+                                return;
+                        }
 		
 			$template->form->setData();
 			unset($template->form->error);

--- a/app/tpl/skins/Mango/account.php
+++ b/app/tpl/skins/Mango/account.php
@@ -58,7 +58,8 @@ Welcome back, {username}
 <?php if(isset($template->form->error)) { echo '<div id="message">'.$template->form->error.'</div>'; } ?>
 From here you can modify your account information such as email address and password! <br/> 
 <br/> 
-<form action="" method="post"> 
+<form action="" method="post">
+<input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
 <table width="766" border="0"> 
 <tr> 
 <td width="150"><strong>Email</strong></td> 

--- a/app/tpl/skins/Mango/index.php
+++ b/app/tpl/skins/Mango/index.php
@@ -9,7 +9,8 @@
 <strong>Welcome to {hotelName}!</strong><br/> 
 Please login with your account or click Register to create one
 <div style="height:5px;"></div> 
-<form action="index" method="post"> 
+<form action="index" method="post">
+<input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
 <table width="200" border="0"> 
 <tr> 
 <td>Username<br/> 

--- a/app/tpl/skins/Mango/register.php
+++ b/app/tpl/skins/Mango/register.php
@@ -5,7 +5,8 @@
 <hr/>  
 <?php if(isset($template->form->error)) { echo '<div id="message">'.$template->form->error.'</div>'; } ?>
 Welcome to {hotelName}! We're very excited to meet you, complete the following form and you will get a account with us and <?php echo $_CONFIG['hotel']['credits']; ?> free credits! We'll see you inside!<br/><br/> 
-<form action="register" method="post"> 
+<form action="register" method="post">
+<input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
 <table width="100%" border="0"> 
 <tr> 
 <td width="25%">Username:</td> 

--- a/global.php
+++ b/global.php
@@ -104,7 +104,11 @@ use Revolution as Rev;
 		
 	//START	
 	
-	session_start();
+        session_start();
+
+        if (!isset($_SESSION['csrf_token'])) {
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        }
 	
 $engine->Initiate();
 


### PR DESCRIPTION
## Summary
- generate CSRF token at startup
- include CSRF token on login, register and account forms
- check CSRF token before processing form submissions

## Testing
- `php -l global.php`
- `php -l app/class.users.php`
- `php -l app/tpl/skins/Mango/index.php`
- `php -l app/tpl/skins/Mango/register.php`
- `php -l app/tpl/skins/Mango/account.php`


------
https://chatgpt.com/codex/tasks/task_e_688ae5272dc08323aa357457473b90aa