### PR TITLE
Ensure prepared statements across PHP pages

### DIFF
--- a/app/tpl/class.forms.php
+++ b/app/tpl/class.forms.php
@@ -83,7 +83,8 @@ class forms implements iForms
 	{
 		global $template, $engine;
                 $a = 1;
-                $stmt = $engine->query("SELECT title, id, published, shortstory, image FROM cms_news ORDER BY id DESC LIMIT 5");
+                $stmt = $engine->prepare("SELECT title, id, published, shortstory, image FROM cms_news ORDER BY id DESC LIMIT 5");
+                $stmt->execute();
 
         while($news = $stmt->fetch())
         {

--- a/app/tpl/skins/Mango/hk/banlist.php
+++ b/app/tpl/skins/Mango/hk/banlist.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
+                        <?php if($_SESSION['user']['rank'] >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
+                        <?php } if($_SESSION['user']['rank'] >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />
@@ -56,7 +56,8 @@
           <table width="100%">
 <tr><td><b>Username</b></td><td><b>Reason</b></td><td><b>Banned by</b></td><td><b>Value</b></td></tr>
 <?php
-        $stmt = $engine->query("SELECT * FROM bans");
+        $stmt = $engine->prepare("SELECT * FROM bans");
+        $stmt->execute();
         while($two = $stmt->fetch())
         {
                 echo "<tr><td>" . $two['value'] ."</td><td>" . $two['reason'] . "</td><td>" . $two['added_by'] . "</td><td><a href='?url=banlist&unban=" . $two['id'] . "'><b>Unban</b></a></td></tr>";

--- a/app/tpl/skins/Mango/hk/dash.php
+++ b/app/tpl/skins/Mango/hk/dash.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
+                        <?php if($_SESSION['user']['rank'] >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
+                        <?php } if($_SESSION['user']['rank'] >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />

--- a/app/tpl/skins/Mango/hk/edit.php
+++ b/app/tpl/skins/Mango/hk/edit.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-			<?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") > 6)
+                        <?php if($_SESSION['user']['rank'] > 6)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-			<?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
+                        <?php } if($_SESSION['user']['rank'] >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />

--- a/app/tpl/skins/Mango/hk/ip.php
+++ b/app/tpl/skins/Mango/hk/ip.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
+                        <?php if($_SESSION['user']['rank'] >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
+                        <?php } if($_SESSION['user']['rank'] >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />

--- a/app/tpl/skins/Mango/hk/news.php
+++ b/app/tpl/skins/Mango/hk/news.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
+                        <?php if($_SESSION['user']['rank'] >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
+                        <?php } if($_SESSION['user']['rank'] >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />
@@ -54,7 +54,7 @@
           <br />         
         <?php
 
-if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
+if($_SESSION['user']['rank'] >= 7)
 {
 	if(isset($_GET["done"]))
 	{

--- a/app/tpl/skins/Mango/hk/news2.php
+++ b/app/tpl/skins/Mango/hk/news2.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
+                        <?php if($_SESSION['user']['rank'] >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
+                        <?php } if($_SESSION['user']['rank'] >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />

--- a/app/tpl/skins/Mango/hk/svip.php
+++ b/app/tpl/skins/Mango/hk/svip.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
+                        <?php if($_SESSION['user']['rank'] >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
+                        <?php } if($_SESSION['user']['rank'] >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />
@@ -61,7 +61,8 @@
                 $stmt->execute([filter($_POST['username'])]);
                 if($stmt->fetchColumn() == 0){ echo "User does not exist."; }
                 else {
-                $engine->query("UPDATE users SET rank = 3, credits = credits + '2000000', activity_points = activity_points + '2000000' WHERE username = '" . filter($_POST['username']) . "'"); }
+                $stmt = $engine->prepare("UPDATE users SET rank = 3, credits = credits + '2000000', activity_points = activity_points + '2000000' WHERE username = ?");
+                $stmt->execute([filter($_POST['username'])]); }
         }
 	
 ?>

--- a/app/tpl/skins/Mango/hk/vip.php
+++ b/app/tpl/skins/Mango/hk/vip.php
@@ -17,7 +17,7 @@
            <br />
 		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />
             <p>
-                        <?php if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 7)
+                        <?php if($_SESSION['user']['rank'] >= 7)
 			{ ?>
 			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />
@@ -28,7 +28,7 @@
 			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='news'>Post news article</a><br />
 			<br />
-                        <?php } if($engine->result("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'") >= 5) { ?>
+                        <?php } if($_SESSION['user']['rank'] >= 5) { ?>
 			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />
 			&raquo; <a href='banlist'>Ban List</a> <br />
 			&raquo; <a href='ip'>IP lookup</a> <br />

--- a/app/tpl/skins/Mango/me.php
+++ b/app/tpl/skins/Mango/me.php
@@ -38,7 +38,8 @@ Welcome back to {hotelName}, {username}!
 <div id="main_left"> 
 
 <?php
-        $stmtRanks = $engine->query("SELECT id,name FROM ranks WHERE id > 3 ORDER BY id DESC");
+        $stmtRanks = $engine->prepare("SELECT id,name FROM ranks WHERE id > 3 ORDER BY id DESC");
+        $stmtRanks->execute();
         while($Ranks = $stmtRanks->fetch())
         {
                 echo "<div class=\"content-box\" style=\"background-color:#fff\"><div class=\"content-box-deep-blue\"><h2 class=\"title\" style=\"padding:0;line-height:30px;\">{$Ranks['name']}s</h2></div><div class=\"content-box-content\"><p>";

--- a/app/tpl/skins/Mango/staff.php
+++ b/app/tpl/skins/Mango/staff.php
@@ -38,7 +38,8 @@ Welcome back to {hotelName}, {username}!
 <div id="main_left"> 
 
 <?php
-        $stmtRanks = $engine->query("SELECT id,name FROM ranks WHERE id > 3 ORDER BY id DESC");
+        $stmtRanks = $engine->prepare("SELECT id,name FROM ranks WHERE id > 3 ORDER BY id DESC");
+        $stmtRanks->execute();
         while($Ranks = $stmtRanks->fetch())
         {
                 echo "<div class=\"content-box\" style=\"background-color:#fff\"><div class=\"content-box-deep-blue\"><h2 class=\"title\" style=\"padding:0;line-height:30px;\">{$Ranks['name']}s</h2></div><div class=\"content-box-content\"><p>";


### PR DESCRIPTION
## Summary
- convert remaining uses of `$engine->query()` to prepared statements
- rely on cached user rank instead of querying for each Housekeeping page
- keep PHP lint checks green

## Testing
- `find . -name '*.php' -print0 | xargs -0 php -l`

------
https://chatgpt.com/codex/tasks/task_e_688ae3ac3980832390fb69bd8f8a8035