### PR TITLE
Secure HK forms with CSRF protection

### DIFF
--- a/app/class.users.php
+++ b/app/class.users.php
@@ -261,14 +261,19 @@ class users implements iUsers
 		}
 	}
 	
-	final public function loginHK()
-	{
-		global $template, $_CONFIG, $core;
-		
-		if(isset($_POST['login']))
-		{	
-			$template->form->setData();
-			unset($template->form->error);
+        final public function loginHK()
+        {
+                global $template, $_CONFIG, $core;
+
+                if(isset($_POST['login']))
+                {
+                        if(!$this->validCsrf())
+                        {
+                                $template->form->error = 'Invalid CSRF token';
+                                return;
+                        }
+                        $template->form->setData();
+                        unset($template->form->error);
 			
 			if(isset($template->form->username) && isset($template->form->password))
 			{

--- a/app/tpl/skins/Mango/hk/edit.php
+++ b/app/tpl/skins/Mango/hk/edit.php
@@ -55,15 +55,27 @@
          <?php
           
         if(isset($_POST['update']))
-		{
-                        $stmt = $engine->prepare("UPDATE users SET username = ?, mail = ?, motto = ?, rank = ?, credits = ?, activity_points = ? WHERE username = ?");
-                        $stmt->execute([filter($_POST["username"]), filter($_POST["email"]), filter($_POST["motto"]), filter($_POST["rank"]), filter($_POST["credits"]), filter($_POST["pixels"]), filter($_POST["username_current"])]);
-		}
+                {
+                        if(!$users->validCsrf())
+                        {
+                                echo 'Invalid CSRF token';
+                        }
+                        else
+                        {
+                                $stmt = $engine->prepare("UPDATE users SET username = ?, mail = ?, motto = ?, rank = ?, credits = ?, activity_points = ? WHERE username = ?");
+                                $stmt->execute([filter($_POST["username"]), filter($_POST["email"]), filter($_POST["motto"]), filter($_POST["rank"]), filter($_POST["credits"]), filter($_POST["pixels"]), filter($_POST["username_current"])]);
+                        }
+                }
 		
 
 if(isset($_POST['lookup']))
-{	
-	
+{
+        if(!$users->validCsrf())
+        {
+                echo 'Invalid CSRF token';
+        }
+        else
+        {
         $stmt = $engine->prepare("SELECT * FROM users WHERE username = ?");
         $stmt->execute([filter($_POST["l_username"])]);
         if($stmt->rowCount() == 0) { echo "User does not exist."; }
@@ -71,8 +83,9 @@ if(isset($_POST['lookup']))
                                 $two = $stmt->fetch();
 ?>
 	Editing account: <?php echo $username; ?></a>
-	<form method='post'>
-	<input type="hidden" name="username_current" value="<?php echo $_POST['l_username']; ?>" />
+        <form method='post'>
+        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
+        <input type="hidden" name="username_current" value="<?php echo $_POST['l_username']; ?>" />
 	
 		<table style="width: 100%;">
 				
@@ -104,13 +117,15 @@ if(isset($_POST['lookup']))
 		<input type="submit" value="  Update account  " name="update"/>
 	</form>
 	<br />
-	<?php
-	}
-	}
-	?>
+        <?php
+        }
+        }
+        }
+        ?>
 
-	<form method='post'>
-	Username <br /> <input type="text" name="l_username" /> <br /> <br />
+        <form method='post'>
+        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
+        Username <br /> <input type="text" name="l_username" /> <br /> <br />
 	<input type="submit" value="  Lookup user  " name="lookup"/>
 	</form>
 
@@ -122,4 +137,4 @@ if(isset($_POST['lookup']))
   </div>
    <center>Powered by ZapASE by Jontycat - Design by Predict</center>
    <center>Implemented into RevCMS by Kryptos</center><br />
-    <div id="links"></div>    <div id="header">      <div id="logo">        <div id="logo_text">          <!-- class="logo_colour", allows you to change the color of the logo text -->          <h1>ASE</h1>        </div>      </div>    </div>    <div id="site_content">      <div id="sidebar_container">        <!-- insert your sidebar items here -->        <div class="sidebar">          <div class="sidebar_top"></div>          <div class="sidebar_item">           <br />		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />            <p>			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) > 6)			{ ?>			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />			&raquo; <a href='vip'>Give a user Regular VIP</a> <br />			&raquo; <a href='svip'>Give a user Super VIP</a> <br />			&raquo; <a href='edit'>Edit a users account</a> <br />			<br />			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='news'>Post news article</a><br />			<br />			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='banlist'>Ban List</a> <br />			&raquo; <a href='ip'>IP lookup</a> <br />			<br />						<?php } ?>			<br />			Statistics<br />			<img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />					Server Status: 			{status} <br />			{online} user(s) online <br />				</p>          </div>          <div class="sidebar_base"></div>        </div>      </div>      <div id="content_container">        <div id="content">          <!-- insert the page content here -->          <br />                   <?php                  if(isset($_POST['update']))		{			mysql_query("UPDATE users SET username = '" . filter($_POST['username']) . "', mail = '" . filter($_POST['email']) . 		"', motto = '" . filter($_POST['motto']) . "', rank = '" . filter($_POST['rank']) . "', credits = '" . filter($_POST['credits']) . "', activity_points = '" . filter($_POST['pixels']) . "' WHERE username = '" . filter($_POST['username_current']) . "'") or die(mysql_error());			 	echo $_POST['username_current'] . "'s account updated."; 		}		if(isset($_POST['lookup'])){			if(mysql_num_rows(mysql_query("SELECT * FROM users WHERE username = '". filter($_POST['l_username']) ."'")) == 0) { echo "User does not exist."; }	else { 				$two = mysql_fetch_assoc(mysql_query("SELECT * FROM users WHERE username = '" . filter($_POST['l_username']) . "'"));	?>		Editing account: <?php echo $username; ?></a>	<form method='post'>	<input type="hidden" name="username_current" value="<?php echo $_POST['l_username']; ?>" />			<table style="width: 100%;">							<tr>				<td>Username</td></td>				<td><input type="text" name="username" value="<?php echo $_POST['l_username']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Email</td>				<td><input type="text" name="email" value="<?php echo $two['mail']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Motto</td>				<td><input type="text" name="motto" value="<?php echo $two['motto']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Rank</td>				<td><input type="text" name="rank" value="<?php echo $two['rank']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Credits</td>				<td><input type="text" name="credits" value="<?php echo $two['credits']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Pixels</td>				<td><input type="text" name="pixels" value="<?php echo $two['activity_points']; ?>" style="width: 95%" /></td>			</tr>		</table>		<input type="submit" value="  Update account  " name="update"/>	</form>	<br />	<?php	}	}	?>	<form method='post'>	Username <br /> <input type="text" name="l_username" /> <br /> <br />	<input type="submit" value="  Lookup user  " name="lookup"/>	</form></div>        </div>      </div>    </div>  </div>   <center>Powered by ZapASE by Jontycat - Design by Predict</center>   <center>Implemented into RevCMS by Kryptos</center><br />
+    <div id="header">      <div id="logo">        <div id="logo_text">          <!-- class="logo_colour", allows you to change the color of the logo text -->          <h1>ASE</h1>        </div>      </div>    </div>    <div id="site_content">      <div id="sidebar_container">        <!-- insert your sidebar items here -->        <div class="sidebar">          <div class="sidebar_top"></div>          <div class="sidebar_item">           <br />		   [ <a href='dash'>Return to Dashboard</a> ] [ <a href='logout.php'>Log out</a> ]<br /> <br />            <p>			<?php if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) > 6)			{ ?>			Player Management <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='sub'>Last 50 VIP purchases</a> <br />			&raquo; <a href='vip'>Give a user Regular VIP</a> <br />			&raquo; <a href='svip'>Give a user Super VIP</a> <br />			&raquo; <a href='edit'>Edit a users account</a> <br />			<br />			Administration <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='news'>Post news article</a><br />			<br />			<?php } if(mysql_result(mysql_query("SELECT rank FROM users WHERE id = '" . $_SESSION['user']['id'] . "'"), 0) >= 5) { ?>			Moderation <br /> <img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />			&raquo; <a href='banlist'>Ban List</a> <br />			&raquo; <a href='ip'>IP lookup</a> <br />			<br />						<?php } ?>			<br />			Statistics<br />			<img src='../app/tpl/skins/<?php echo $_CONFIG['template']['style']; ?>/hk/images/line.png'> <br />					Server Status: 			{status} <br />			{online} user(s) online <br />				</p>          </div>          <div class="sidebar_base"></div>        </div>      </div>      <div id="content_container">        <div id="content">          <!-- insert the page content here -->          <br />                   <?php                  if(isset($_POST['update']))		{			mysql_query("UPDATE users SET username = '" . filter($_POST['username']) . "', mail = '" . filter($_POST['email']) . 		"', motto = '" . filter($_POST['motto']) . "', rank = '" . filter($_POST['rank']) . "', credits = '" . filter($_POST['credits']) . "', activity_points = '" . filter($_POST['pixels']) . "' WHERE username = '" . filter($_POST['username_current']) . "'") or die(mysql_error());			 	echo $_POST['username_current'] . "'s account updated."; 		}		if(isset($_POST['lookup'])){			if(mysql_num_rows(mysql_query("SELECT * FROM users WHERE username = '". filter($_POST['l_username']) ."'")) == 0) { echo "User does not exist."; }	else { 				$two = mysql_fetch_assoc(mysql_query("SELECT * FROM users WHERE username = '" . filter($_POST['l_username']) . "'"));	?>		Editing account: <?php echo $username; ?></a>	<form method='post'>	<input type="hidden" name="username_current" value="<?php echo $_POST['l_username']; ?>" />			<table style="width: 100%;">							<tr>				<td>Username</td></td>				<td><input type="text" name="username" value="<?php echo $_POST['l_username']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Email</td>				<td><input type="text" name="email" value="<?php echo $two['mail']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Motto</td>				<td><input type="text" name="motto" value="<?php echo $two['motto']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Rank</td>				<td><input type="text" name="rank" value="<?php echo $two['rank']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Credits</td>				<td><input type="text" name="credits" value="<?php echo $two['credits']; ?>" style="width: 95%" /></td>			</tr>			<tr>				<td>Pixels</td>				<td><input type="text" name="pixels" value="<?php echo $two['activity_points']; ?>" style="width: 95%" /></td>			</tr>		</table>		<input type="submit" value="  Update account  " name="update"/>	</form>	<br />	<?php	}	}	?>	<form method='post'>	Username <br /> <input type="text" name="l_username" /> <br /> <br />	<input type="submit" value="  Lookup user  " name="lookup"/>	</form></div>        </div>      </div>    </div>  </div>   <center>Powered by ZapASE by Jontycat - Design by Predict</center>   <center>Implemented into RevCMS by Kryptos</center><br />

--- a/app/tpl/skins/Mango/hk/ip.php
+++ b/app/tpl/skins/Mango/hk/ip.php
@@ -58,6 +58,12 @@
 <?php
         if(isset($_POST['get_ip']))
         {
+                if(!$users->validCsrf())
+                {
+                        echo 'Invalid CSRF token';
+                }
+                else
+                {
                 $stmt = $engine->prepare("SELECT ip_last FROM users WHERE username = ?");
                 $stmt->execute([filter($_POST['username'])]);
                 $derp = $stmt->fetch();
@@ -70,12 +76,14 @@
                 foreach($accounts as $ferp) {
                 echo "<tr><td>" . $ferp['username'] . "</td><td>" . $ferp['mail'] . "</td><td>" . $ferp['ip_last'] . "</td></tr>"; }
                 $engine->free_result($stmt);
+                }
         } ?>
 	
-	<form method='post'>
-	Username <br /> <input type="text" name="username" /> <br /> <br />
-	<input type="submit" value="  Lookup IP  " name="get_ip"/>
-	</form>
+        <form method='post'>
+        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
+        Username <br /> <input type="text" name="username" /> <br /> <br />
+        <input type="submit" value="  Lookup IP  " name="get_ip"/>
+        </form>
 </table>
 
         </div>

--- a/app/tpl/skins/Mango/hk/login.php
+++ b/app/tpl/skins/Mango/hk/login.php
@@ -14,9 +14,10 @@
 			 <?php echo $template->form->error; ?>
 			
 			<br />
-				<form method="post" action="index.php?url=login">
-				Username: <br /> <input type="text" name="username" class="login"/> <br /> <br />
-				Password: <br /> <input type="password" name="password" class="login"/> <br /> <br /><br />
+                                <form method="post" action="index.php?url=login">
+                                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
+                                Username: <br /> <input type="text" name="username" class="login"/> <br /> <br />
+                                Password: <br /> <input type="password" name="password" class="login"/> <br /> <br /><br />
 						<input type="submit" value="Log into ASE" name="login" class="login"/>
 				</form><br /><br />     <center>Powered by ZapASE by Jontycat - Design by Predict</center>
   	<center>Implemented into RevCMS by Kryptos</center><br />

--- a/app/tpl/skins/Mango/hk/news.php
+++ b/app/tpl/skins/Mango/hk/news.php
@@ -65,16 +65,20 @@ if($_SESSION['user']['rank'] >= 7)
 			exit;
 		}
 	}
-	if(isset($_POST["step1"]))
-	{
-		if($_POST["title"] == NULL || $_POST["shortstory"] == NULL || $_POST["longstory"] == NULL)
-		{
-			echo "<h2>Please fill in all the fields!</h2>";
-		}
-		else
-		{
-			$_SESSION["title"] = filter($_POST["title"]);
-			$_SESSION["shortstory"] = filter($_POST["shortstory"]);
+        if(isset($_POST["step1"]))
+        {
+                if(!$users->validCsrf())
+                {
+                        echo 'Invalid CSRF token';
+                }
+                elseif($_POST["title"] == NULL || $_POST["shortstory"] == NULL || $_POST["longstory"] == NULL)
+                {
+                        echo "<h2>Please fill in all the fields!</h2>";
+                }
+                else
+                {
+                        $_SESSION["title"] = filter($_POST["title"]);
+                        $_SESSION["shortstory"] = filter($_POST["shortstory"]);
                         $_SESSION["longstory"] = filter($_POST["longstory"]);
 			
 			header("Location: ".$_CONFIG['hotel']['url']."/ase/news2");
@@ -95,8 +99,9 @@ if($_SESSION['user']['rank'] >= 7)
 		  });
 		  </script>
 
-	<form method="post">
-	Title of the news article <br />
+        <form method="post">
+        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
+        Title of the news article <br />
 	<input type="text" name="title"/> <br /> <br />
 	Short story <br />
 	<input type="text" name="shortstory"/> <br /> <br />

--- a/app/tpl/skins/Mango/hk/news2.php
+++ b/app/tpl/skins/Mango/hk/news2.php
@@ -62,18 +62,26 @@ if(!isset($_SESSION["longstory"]))
 
 if(isset($_POST["proceed"]))
 {
+        if(!$users->validCsrf())
+        {
+                echo 'Invalid CSRF token';
+        }
+        else
+        {
         $stmt = $engine->prepare("SELECT username FROM users WHERE id = ? LIMIT 1");
         $stmt->execute([$_SESSION['user']['id']]);
         $author = $stmt->fetchColumn();
         $engine->free_result($stmt);
         $stmt = $engine->prepare("INSERT INTO cms_news (title,shortstory,longstory,published,image,author, campaign, campaignimg) VALUES (?, ?, ?, ?, ?, ?, 0, 'default')");
         $stmt->execute([filter($_SESSION["title"]), filter($_SESSION["shortstory"]), filter($_SESSION["longstory"]), time(), filter($_POST["topstory"]), filter($author)]);
-	unset($_SESSION["title"], $_SESSION["shortstory"], $_SESSION["longstory"]);
-	header("Location: ".$_CONFIG['hotel']['url']."/ase/");
-	exit;
+        unset($_SESSION["title"], $_SESSION["shortstory"], $_SESSION["longstory"]);
+        header("Location: ".$_CONFIG['hotel']['url']."/ase/");
+        exit;
+        }
 }
 	echo '<center><b>It\'s time to choose the image for your story. Choose one from the drop down list and click "Check Image"';
-	echo '<form method="post">';
+        echo '<form method="post">';
+        echo '<input type="hidden" name="csrf_token" value="'.$_SESSION['csrf_token'].'"/>';
 	echo '<br />';
 	echo '<select name="topstory" id="topstory" style="font-size: 14px;"';
 	

--- a/app/tpl/skins/Mango/hk/svip.php
+++ b/app/tpl/skins/Mango/hk/svip.php
@@ -57,17 +57,25 @@
      
         if(isset($_POST['give']))
         {
-                $stmt = $engine->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
-                $stmt->execute([filter($_POST['username'])]);
-                if($stmt->fetchColumn() == 0){ echo "User does not exist."; }
-                else {
-                $stmt = $engine->prepare("UPDATE users SET rank = 3, credits = credits + '2000000', activity_points = activity_points + '2000000' WHERE username = ?");
-                $stmt->execute([filter($_POST['username'])]); }
+                if(!$users->validCsrf())
+                {
+                        echo 'Invalid CSRF token';
+                }
+                else
+                {
+                        $stmt = $engine->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
+                        $stmt->execute([filter($_POST['username'])]);
+                        if($stmt->fetchColumn() == 0){ echo "User does not exist."; }
+                        else {
+                        $stmt = $engine->prepare("UPDATE users SET rank = 3, credits = credits + '2000000', activity_points = activity_points + '2000000' WHERE username = ?");
+                        $stmt->execute([filter($_POST['username'])]); }
+                }
         }
 	
 ?>
-				<form method="post">
-				Username <br /> <input type="text" name="username" /> <br /> <br />
+                                <form method="post">
+                                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
+                                Username <br /> <input type="text" name="username" /> <br /> <br />
 				<input type="submit" value="  Give Super VIP  " name="give"/>
 				</form>
 

--- a/app/tpl/skins/Mango/hk/vip.php
+++ b/app/tpl/skins/Mango/hk/vip.php
@@ -55,18 +55,26 @@
           <?php
         if(isset($_POST['give']))
         {
-                $stmt = $engine->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
-                $stmt->execute([filter($_POST['username'])]);
-                if($stmt->fetchColumn() == 0){ echo "User does not exist."; }
-                else {
-                $stmt = $engine->prepare("UPDATE users SET rank = 2, credits = credits + '200000', activity_points = activity_points + '200000' WHERE username = ?");
-                $stmt->execute([$_POST['username']]);
+                if(!$users->validCsrf())
+                {
+                        echo 'Invalid CSRF token';
+                }
+                else
+                {
+                        $stmt = $engine->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
+                        $stmt->execute([filter($_POST['username'])]);
+                        if($stmt->fetchColumn() == 0){ echo "User does not exist."; }
+                        else {
+                        $stmt = $engine->prepare("UPDATE users SET rank = 2, credits = credits + '200000', activity_points = activity_points + '200000' WHERE username = ?");
+                        $stmt->execute([$_POST['username']]);
+                        }
                 }
         }
 	
 ?>
-				<form method="post">
-				Username <br /> <input type="text" name="username" /> <br /> <br />
+                                <form method="post">
+                                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
+                                Username <br /> <input type="text" name="username" /> <br /> <br />
 				<input type="submit" value="  Give Regular VIP  " name="give"/>
 				</form>
 


### PR DESCRIPTION
## Summary
- add CSRF validation to HK login function
- validate CSRF tokens for forms in Mango HK templates
- include hidden CSRF inputs in those forms

## Testing
- `php -l app/class.users.php`
- `php -l app/tpl/skins/Mango/hk/edit.php`
- `php -l app/tpl/skins/Mango/hk/ip.php`
- `php -l app/tpl/skins/Mango/hk/login.php`
- `php -l app/tpl/skins/Mango/hk/news.php`
- `php -l app/tpl/skins/Mango/hk/news2.php`
- `php -l app/tpl/skins/Mango/hk/svip.php`
- `php -l app/tpl/skins/Mango/hk/vip.php`


------
https://chatgpt.com/codex/tasks/task_e_688b0393642c8323b6cbd3fa9ffdabe4