### PR TITLE
Refactor input handling

### DIFF
--- a/app/tpl/skins/Mango/hk/edit.php
+++ b/app/tpl/skins/Mango/hk/edit.php
@@ -57,7 +57,7 @@
         if(isset($_POST['update']))
 		{
                         $stmt = $engine->prepare("UPDATE users SET username = ?, mail = ?, motto = ?, rank = ?, credits = ?, activity_points = ? WHERE username = ?");
-                        $stmt->execute([filter($_POST["username"]), filter($_POST["email"]), filter($_POST["motto"]), filter($_POST["rank"]), filter($_POST["credits"]), filter($_POST["pixels"]), filter($_POST["username_current"])]);
+                        $stmt->execute([$_POST["username"], $_POST["email"], $_POST["motto"], $_POST["rank"], $_POST["credits"], $_POST["pixels"], $_POST["username_current"]]);
 		}
 		
 
@@ -65,40 +65,40 @@ if(isset($_POST['lookup']))
 {	
 	
         $stmt = $engine->prepare("SELECT * FROM users WHERE username = ?");
-        $stmt->execute([filter($_POST["l_username"])]);
+        $stmt->execute([$_POST["l_username"]]);
         if($stmt->rowCount() == 0) { echo "User does not exist."; }
         else {
                                 $two = $stmt->fetch();
 ?>
-	Editing account: <?php echo $username; ?></a>
+        Editing account: <?php echo htmlspecialchars($username, ENT_QUOTES); ?></a>
 	<form method='post'>
-	<input type="hidden" name="username_current" value="<?php echo $_POST['l_username']; ?>" />
+        <input type="hidden" name="username_current" value="<?php echo htmlspecialchars($_POST['l_username'], ENT_QUOTES); ?>" />
 	
 		<table style="width: 100%;">
 				
 			<tr>
 				<td>Username</td></td>
-				<td><input type="text" name="username" value="<?php echo $_POST['l_username']; ?>" style="width: 95%" /></td>
+                                <td><input type="text" name="username" value="<?php echo htmlspecialchars($_POST['l_username'], ENT_QUOTES); ?>" style="width: 95%" /></td>
 			</tr>
 			<tr>
 				<td>Email</td>
-				<td><input type="text" name="email" value="<?php echo $two['mail']; ?>" style="width: 95%" /></td>
+                                <td><input type="text" name="email" value="<?php echo htmlspecialchars($two['mail'], ENT_QUOTES); ?>" style="width: 95%" /></td>
 			</tr>
 			<tr>
 				<td>Motto</td>
-				<td><input type="text" name="motto" value="<?php echo $two['motto']; ?>" style="width: 95%" /></td>
+                                <td><input type="text" name="motto" value="<?php echo htmlspecialchars($two['motto'], ENT_QUOTES); ?>" style="width: 95%" /></td>
 			</tr>
 			<tr>
 				<td>Rank</td>
-				<td><input type="text" name="rank" value="<?php echo $two['rank']; ?>" style="width: 95%" /></td>
+                                <td><input type="text" name="rank" value="<?php echo htmlspecialchars($two['rank'], ENT_QUOTES); ?>" style="width: 95%" /></td>
 			</tr>
 			<tr>
 				<td>Credits</td>
-				<td><input type="text" name="credits" value="<?php echo $two['credits']; ?>" style="width: 95%" /></td>
+                                <td><input type="text" name="credits" value="<?php echo htmlspecialchars($two['credits'], ENT_QUOTES); ?>" style="width: 95%" /></td>
 			</tr>
 			<tr>
 				<td>Pixels</td>
-				<td><input type="text" name="pixels" value="<?php echo $two['activity_points']; ?>" style="width: 95%" /></td>
+                                <td><input type="text" name="pixels" value="<?php echo htmlspecialchars($two['activity_points'], ENT_QUOTES); ?>" style="width: 95%" /></td>
 			</tr>
 		</table>
 		<input type="submit" value="  Update account  " name="update"/>

--- a/app/tpl/skins/Mango/hk/ip.php
+++ b/app/tpl/skins/Mango/hk/ip.php
@@ -59,7 +59,7 @@
         if(isset($_POST['get_ip']))
         {
                 $stmt = $engine->prepare("SELECT ip_last FROM users WHERE username = ?");
-                $stmt->execute([filter($_POST['username'])]);
+                $stmt->execute([$_POST['username']]);
                 $derp = $stmt->fetch();
                 $engine->free_result($stmt);
                 $stmt = $engine->prepare("SELECT * FROM users WHERE ip_last = ?");
@@ -68,7 +68,7 @@
 
                 echo "There are " . count($accounts) . " account(s) on this IP. <br /><br />";
                 foreach($accounts as $ferp) {
-                echo "<tr><td>" . $ferp['username'] . "</td><td>" . $ferp['mail'] . "</td><td>" . $ferp['ip_last'] . "</td></tr>"; }
+                echo "<tr><td>" . htmlspecialchars($ferp['username'], ENT_QUOTES) . "</td><td>" . htmlspecialchars($ferp['mail'], ENT_QUOTES) . "</td><td>" . htmlspecialchars($ferp['ip_last'], ENT_QUOTES) . "</td></tr>"; }
                 $engine->free_result($stmt);
         } ?>
 	

--- a/app/tpl/skins/Mango/hk/news.php
+++ b/app/tpl/skins/Mango/hk/news.php
@@ -58,7 +58,7 @@ if($_SESSION['user']['rank'] >= 7)
 {
 	if(isset($_GET["done"]))
 	{
-		$get = filter($_GET["done"]);
+                $get = $_GET["done"];
 		if($get == true)
 		{
 			echo '<h3>Article posted.</h3>';
@@ -73,9 +73,9 @@ if($_SESSION['user']['rank'] >= 7)
 		}
 		else
 		{
-			$_SESSION["title"] = filter($_POST["title"]);
-			$_SESSION["shortstory"] = filter($_POST["shortstory"]);
-                        $_SESSION["longstory"] = filter($_POST["longstory"]);
+                        $_SESSION["title"] = $_POST["title"];
+                        $_SESSION["shortstory"] = $_POST["shortstory"];
+                        $_SESSION["longstory"] = $_POST["longstory"];
 			
 			header("Location: ".$_CONFIG['hotel']['url']."/ase/news2");
 			exit;

--- a/app/tpl/skins/Mango/hk/news2.php
+++ b/app/tpl/skins/Mango/hk/news2.php
@@ -67,7 +67,7 @@ if(isset($_POST["proceed"]))
         $author = $stmt->fetchColumn();
         $engine->free_result($stmt);
         $stmt = $engine->prepare("INSERT INTO cms_news (title,shortstory,longstory,published,image,author, campaign, campaignimg) VALUES (?, ?, ?, ?, ?, ?, 0, 'default')");
-        $stmt->execute([filter($_SESSION["title"]), filter($_SESSION["shortstory"]), filter($_SESSION["longstory"]), time(), filter($_POST["topstory"]), filter($author)]);
+        $stmt->execute([$_SESSION["title"], $_SESSION["shortstory"], $_SESSION["longstory"], time(), $_POST["topstory"], $author]);
 	unset($_SESSION["title"], $_SESSION["shortstory"], $_SESSION["longstory"]);
 	header("Location: ".$_CONFIG['hotel']['url']."/ase/");
 	exit;
@@ -86,14 +86,14 @@ if(isset($_POST["proceed"]))
 				continue;
 			}	
 	
-			echo '<option value="' . $file . '"';
+                        echo '<option value="' . htmlspecialchars($file, ENT_QUOTES) . '"';
 	
-			if (isset($_POST['topstory']) && $_POST['topstory'] == $file)
+                        if (isset($_POST['topstory']) && $_POST['topstory'] == $file)
 			{
 				echo ' selected';
 			}
 			
-			echo '>' . $file . '</option>';
+                        echo '>' . htmlspecialchars($file, ENT_QUOTES) . '</option>';
 		}
 	}
 
@@ -102,7 +102,7 @@ if(isset($_POST["proceed"]))
 	if(isset($_POST["check"]))
 	{
 		echo '<br /> <br /> <input type="submit" value="  Check image  " name="check" /> <br /><br />';
-		echo '<font size="3">Topstory image<br /></font><img src="ts/' . $_POST["topstory"] . '" align="right />';
+                echo '<font size="3">Topstory image<br /></font><img src="ts/' . htmlspecialchars($_POST["topstory"], ENT_QUOTES) . '" align="right />';
 		echo '</center> <align="right"> <br /> <br /> <input type="submit" value="  Proceed (use image)  " name="proceed" /> <br />';
 		echo '</form>';
 	}

--- a/app/tpl/skins/Mango/hk/svip.php
+++ b/app/tpl/skins/Mango/hk/svip.php
@@ -58,11 +58,11 @@
         if(isset($_POST['give']))
         {
                 $stmt = $engine->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
-                $stmt->execute([filter($_POST['username'])]);
+                $stmt->execute([$_POST['username']]);
                 if($stmt->fetchColumn() == 0){ echo "User does not exist."; }
                 else {
                 $stmt = $engine->prepare("UPDATE users SET rank = 3, credits = credits + '2000000', activity_points = activity_points + '2000000' WHERE username = ?");
-                $stmt->execute([filter($_POST['username'])]); }
+                $stmt->execute([$_POST['username']]); }
         }
 	
 ?>

--- a/app/tpl/skins/Mango/hk/vip.php
+++ b/app/tpl/skins/Mango/hk/vip.php
@@ -56,7 +56,7 @@
         if(isset($_POST['give']))
         {
                 $stmt = $engine->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
-                $stmt->execute([filter($_POST['username'])]);
+                $stmt->execute([$_POST['username']]);
                 if($stmt->fetchColumn() == 0){ echo "User does not exist."; }
                 else {
                 $stmt = $engine->prepare("UPDATE users SET rank = 2, credits = credits + '200000', activity_points = activity_points + '200000' WHERE username = ?");

--- a/global.php
+++ b/global.php
@@ -1,11 +1,6 @@
 <?php
 
-	// Special Functions
-	
-function filter($var)
-{
-    return addslashes(stripslashes(htmlspecialchars($var, ENT_QUOTES)));
-}
+        // Special Functions removed: input handling now done with parameter binding and htmlspecialchars
 
 if(!defined('IN_INDEX')) { die('Sorry, you cannot access this file.'); }
 if(isset($_SERVER['HTTP_CF_CONNECTING_IP'])) { $_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_CF_CONNECTING_IP']; }


### PR DESCRIPTION
## Summary
- sanitize DB input with PDO parameter binding
- escape dynamic values in HTML with `htmlspecialchars`
- remove obsolete `filter` helper

## Testing
- `php -l global.php`
- `php -l app/tpl/skins/Mango/hk/svip.php`
- `php -l app/tpl/skins/Mango/hk/vip.php`
- `php -l app/tpl/skins/Mango/hk/ip.php`
- `php -l app/tpl/skins/Mango/hk/news.php`
- `php -l app/tpl/skins/Mango/hk/news2.php`
- `php -l app/tpl/skins/Mango/hk/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_688b039ae18c8323a8501dea90942ece