### PR TITLE
Improve HK scripts security checks

### DIFF
--- a/app/class.users.php
+++ b/app/class.users.php
@@ -265,10 +265,15 @@ class users implements iUsers
 	{
 		global $template, $_CONFIG, $core;
 		
-		if(isset($_POST['login']))
-		{	
-			$template->form->setData();
-			unset($template->form->error);
+                if(isset($_POST['login']))
+                {
+                        if(!$this->validCsrf())
+                        {
+                                $template->form->error = 'Invalid CSRF token';
+                                return;
+                        }
+                        $template->form->setData();
+                        unset($template->form->error);
 			
 			if(isset($template->form->username) && isset($template->form->password))
 			{

--- a/app/tpl/skins/Mango/hk/login.php
+++ b/app/tpl/skins/Mango/hk/login.php
@@ -16,8 +16,10 @@
 			<br />
 				<form method="post" action="index.php?url=login">
 				Username: <br /> <input type="text" name="username" class="login"/> <br /> <br />
-				Password: <br /> <input type="password" name="password" class="login"/> <br /> <br /><br />
-						<input type="submit" value="Log into ASE" name="login" class="login"/>
+                                Password: <br /> <input type="password" name="password" class="login"/> <br />
+                                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
+                                <br /><br />
+                                                <input type="submit" value="Log into ASE" name="login" class="login"/>
 				</form><br /><br />     <center>Powered by ZapASE by Jontycat - Design by Predict</center>
   	<center>Implemented into RevCMS by Kryptos</center><br />
         </div>

--- a/app/tpl/skins/Mango/hk/vip.php
+++ b/app/tpl/skins/Mango/hk/vip.php
@@ -55,20 +55,50 @@
           <?php
         if(isset($_POST['give']))
         {
-                $stmt = $engine->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
-                $stmt->execute([filter($_POST['username'])]);
-                if($stmt->fetchColumn() == 0){ echo "User does not exist."; }
-                else {
-                $stmt = $engine->prepare("UPDATE users SET rank = 2, credits = credits + '200000', activity_points = activity_points + '200000' WHERE username = ?");
-                $stmt->execute([$_POST['username']]);
+                if(!$users->validCsrf())
+                {
+                        echo "Invalid CSRF token.";
+                }
+                else
+                {
+                        $stmt = $engine->prepare("SELECT credits, activity_points FROM users WHERE username = ?");
+                        $stmt->execute([filter($_POST['username'])]);
+                        $data = $stmt->fetch();
+                        if(!$data)
+                        {
+                                echo "User does not exist.";
+                        }
+                        else
+                        {
+                                $credits = $data['credits'] + 200000;
+                                $pixels = $data['activity_points'] + 200000;
+                                if($credits > 100000000 || $pixels > 100000000)
+                                {
+                                        echo "Credit limit exceeded.";
+                                }
+                                else
+                                {
+                                        $stmt = $engine->prepare("UPDATE users SET rank = 2, credits = ?, activity_points = ? WHERE username = ?");
+                                        if($stmt->execute([$credits, $pixels, filter($_POST['username'])]))
+                                        {
+                                                echo "Regular VIP given.";
+                                        }
+                                        else
+                                        {
+                                                echo "Update failed.";
+                                        }
+                                }
+                        }
                 }
         }
 	
 ?>
-				<form method="post">
-				Username <br /> <input type="text" name="username" /> <br /> <br />
-				<input type="submit" value="  Give Regular VIP  " name="give"/>
-				</form>
+                                <form method="post">
+                                Username <br /> <input type="text" name="username" /> <br />
+                                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>"/>
+                                <br />
+                                <input type="submit" value="  Give Regular VIP  " name="give"/>
+                                </form>
 
         </div>
 


### PR DESCRIPTION
## Summary
- validate CSRF token when logging into housekeeping
- embed CSRF fields in HK login and user management forms
- verify user existence, enforce value limits and show messages when editing users or giving VIP

## Testing
- `php -l app/class.users.php`
- `php -l app/tpl/skins/Mango/hk/login.php`
- `php -l app/tpl/skins/Mango/hk/vip.php`
- `php -l app/tpl/skins/Mango/hk/svip.php`
- `php -l app/tpl/skins/Mango/hk/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_688b03b1177c8323be7e91f64b23da8c