### PR TITLE
Remove closing PHP tags

### DIFF
--- a/app/class.core.php
+++ b/app/class.core.php
@@ -178,4 +178,3 @@ class core implements iCore
                 return password_verify($password, $hash);
         }
 }
-?>

--- a/app/class.engine.php
+++ b/app/class.engine.php
@@ -103,4 +103,3 @@ class engine
         return $this->connection;
     }
 }
-?>

--- a/app/class.template.php
+++ b/app/class.template.php
@@ -89,4 +89,3 @@ class template implements iTemplate
 		unset($this->tpl);
 	}
 }
-?>

--- a/app/class.users.php
+++ b/app/class.users.php
@@ -597,4 +597,3 @@ class users implements iUsers
 	}
 	
 }
-?>

--- a/app/interfaces/interface.core.php
+++ b/app/interfaces/interface.core.php
@@ -19,4 +19,3 @@ interface iCore
         public function verifyHash($password, $hash);
 
 }
-?>

--- a/app/interfaces/interface.engine.php
+++ b/app/interfaces/interface.engine.php
@@ -28,4 +28,3 @@ interface iEngine
 	public function free_result($sql);
 	
 }
-?>

--- a/app/interfaces/interface.template.php
+++ b/app/interfaces/interface.template.php
@@ -16,4 +16,3 @@ interface iTemplate
 	public function outputTPL();
 	
 }	
-?>

--- a/app/interfaces/interface.users.php
+++ b/app/interfaces/interface.users.php
@@ -49,4 +49,3 @@ interface iUsers
 
 
 }
-?>

--- a/app/tpl/interfaces/interface.css.php
+++ b/app/tpl/interfaces/interface.css.php
@@ -12,4 +12,3 @@ interface iCSS
 	public function setCSS();
 
 }
-?>

--- a/app/tpl/interfaces/interface.forms.php
+++ b/app/tpl/interfaces/interface.forms.php
@@ -18,4 +18,3 @@ interface iForms
 	public function getPageNews();
 	
 }
-?>

--- a/app/tpl/interfaces/interface.html.php
+++ b/app/tpl/interfaces/interface.html.php
@@ -12,4 +12,3 @@ interface iHTML
 	public function setHTML();
 
 }
-?>

--- a/app/tpl/interfaces/interface.js.php
+++ b/app/tpl/interfaces/interface.js.php
@@ -12,4 +12,3 @@ interface iJS
 	public function setJS();
 
 }
-?>


### PR DESCRIPTION
## Summary
- strip trailing `?>` from PHP-only source files and interfaces

## Testing
- `php -l app/class.core.php`
- `php -l app/class.engine.php`
- `php -l app/class.users.php` *(fails: unexpected token)*
- `php -l app/class.template.php`
- `find app -name '*.php' -print0 | xargs -0 -n1 -I{} sh -c 'php -l "{}" || true'`

------
https://chatgpt.com/codex/tasks/task_e_688b0813305883238239c78af02dc291