### PR TITLE
Update recaptcha crypto and fix SQL concatenation

### DIFF
--- a/app/management/recaptchalib.php
+++ b/app/management/recaptchalib.php
@@ -213,13 +213,11 @@ function _recaptcha_aes_pad($val) {
 /* Mailhide related code */
 
 function _recaptcha_aes_encrypt($val,$ky) {
-	if (! function_exists ("mcrypt_encrypt")) {
-		die ("To use reCAPTCHA Mailhide, you need to have the mcrypt php module installed.");
-	}
-	$mode=MCRYPT_MODE_CBC;   
-	$enc=MCRYPT_RIJNDAEL_128;
-	$val=_recaptcha_aes_pad($val);
-	return mcrypt_encrypt($enc, $ky, $val, $mode, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+        if (! function_exists ("openssl_encrypt")) {
+                die ("To use reCAPTCHA Mailhide, you need to have the openssl php module installed.");
+        }
+        $val=_recaptcha_aes_pad($val);
+        return openssl_encrypt($val, 'AES-128-CBC', $ky, OPENSSL_RAW_DATA, str_repeat("\0", 16));
 }
 
 

--- a/app/tpl/class.forms.php
+++ b/app/tpl/class.forms.php
@@ -68,11 +68,15 @@ class forms implements iForms
                                 }
                                 $engine->free_result($stmt);
 				
-				$news = $engine->fetch_assoc("SELECT title, longstory, author, published FROM cms_news WHERE id = '" . $engine->secure($_GET['id']) . "' LIMIT 1");
-				$template->setParams('newsTitle', $news['title']);
-				$template->setParams('newsContent', $news['longstory']);
-				$template->setParams('newsAuthor', $news['author']);
-				$template->setParams('newsDate', date("d-m-y", $news['published']));
+                                $stmt = $engine->prepare("SELECT title, longstory, author, published FROM cms_news WHERE id = :id LIMIT 1");
+                                $stmt->bindValue(':id', $_GET['id'], \PDO::PARAM_INT);
+                                $stmt->execute();
+                                $news = $stmt->fetch();
+                                $template->setParams('newsTitle', $news['title']);
+                                $template->setParams('newsContent', $news['longstory']);
+                                $template->setParams('newsAuthor', $news['author']);
+                                $template->setParams('newsDate', date("d-m-y", $news['published']));
+                                $engine->free_result($stmt);
 			
 				unset($result);
 				unset($news1);


### PR DESCRIPTION
## Summary
- switch Mailhide AES encryption to OpenSSL
- use parameterized query for news page

## Testing
- `php -l app/management/recaptchalib.php`
- `php -l app/tpl/class.forms.php`


------
https://chatgpt.com/codex/tasks/task_e_688b25c827b88323a97d0cb81b4bfaa7