### PR TITLE
Add whitelist validation for updateUser

### DIFF
--- a/app/class.users.php
+++ b/app/class.users.php
@@ -493,9 +493,33 @@ class users implements iUsers
                $stmt->execute([$k]);
        }
 	  	
-	final public function updateUser($k, $key, $value) 	
-	{ 		
-	 	global $engine; 		 		
+       /**
+        * Update a single column for the given user.
+        *
+        * Allowed keys: ip_last, motto, mail, password, auth_ticket,
+        * credits and activity_points.
+        *
+        * @throws \InvalidArgumentException When an invalid column name is supplied.
+        */
+       final public function updateUser($k, $key, $value)
+       {
+               global $engine;
+
+               $allowed = [
+                       'ip_last',
+                       'motto',
+                       'mail',
+                       'password',
+                       'auth_ticket',
+                       'credits',
+                       'activity_points'
+               ];
+
+               if(!in_array($key, $allowed, true))
+               {
+                       throw new \InvalidArgumentException('Invalid user column');
+               }
+
                if($key == 'credits' || $key == 'activity_points')
                {
                        $type = ($key == 'credits') ? 0 : 5;


### PR DESCRIPTION
## Summary
- restrict allowed fields in `updateUser` to prevent SQL injection
- throw `InvalidArgumentException` for invalid column names
- document allowed keys in a phpdoc comment

## Testing
- `php -l app/class.users.php`


------
https://chatgpt.com/codex/tasks/task_e_688b2e1a39288323bd8edb18a235760e