### PR TITLE
Add 404 handling in router

### DIFF
--- a/app/class.core.php
+++ b/app/class.core.php
@@ -58,9 +58,10 @@ class core implements iCore
 						exit;
 					break;
 					
-					default:
-						//Nothing
-					break;
+                                        default:
+                                                http_response_code(404);
+                                                $_GET['url'] = '404';
+                                        break;
 				}
 			}
 			else
@@ -102,9 +103,10 @@ class core implements iCore
 						$users->updateAccount();
 					break;
 					
-					default:
-						//nothing
-					break;
+                                        default:
+                                                http_response_code(404);
+                                                $_GET['url'] = '404';
+                                        break;
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- send a 404 response when routing fails
- let the template render the 404 page

## Testing
- `composer install --no-interaction`
- `php -l app/class.core.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_688b51785b908323929394b7cd4b68e1