### PR TITLE
Handle missing config.php gracefully

### DIFF
--- a/global.php
+++ b/global.php
@@ -56,9 +56,16 @@ use Revolution as Rev;
 		
 		require_once A . 'class.template.php';
 		
-		//MANAGEMENT
-		
-                        require_once A . M . 'config.php';
+                //MANAGEMENT
+
+                        $configFile = A . M . 'config.php';
+                        if (!file_exists($configFile)) {
+                            echo "Error: missing configuration.\n";
+                            echo "Please copy app/management/config.php.example to app/management/config.php and configure it.";
+                            exit(1);
+                        }
+
+                        require_once $configFile;
 
                         require_once __DIR__ . '/vendor/autoload.php';
 				


### PR DESCRIPTION
## Summary
- add file_exists check before requiring management config
- show clear error message if config.php is missing

## Testing
- `php -l global.php`


------
https://chatgpt.com/codex/tasks/task_e_688b51899d88832390f844c27e585338